### PR TITLE
Setting files to deploy app in heroku server

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: sh setup.sh && streamlit run app.py
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,13 @@
+mkdir -p ~/.streamlit/
+
+echo "\
+[general]\n\
+email = \"buildwithai7@gmail.com\"\n\
+" > ~/.streamlit/credentials.toml
+
+echo "\
+[server]\n\
+headless = true\n\
+enableCORS=false\n\
+port = $PORT\n\
+" > ~/.streamlit/config.toml


### PR DESCRIPTION
### Subject
Setting files to deploy app in heroku server.

### Problem
Prepare `Heroku` container to server `data-product` app.

### Solution
- setting `setup.sh`.
- setting `Procfile`.
